### PR TITLE
Added POWER register for TWIM peripheral.

### DIFF
--- a/pacs/nrf52832-pac/src/twim0.rs
+++ b/pacs/nrf52832-pac/src/twim0.rs
@@ -62,6 +62,9 @@ pub struct RegisterBlock {
     _reserved22: [u8; 0x34],
     #[doc = "0x588 - Address used in the TWI transfer"]
     pub address: ADDRESS,
+    _reserved23: [u8; 0x0a70],
+    #[doc = "0xffc - Peripheral power control register"]
+    pub per_power: PER_POWER,
 }
 #[doc = "TASKS_STARTRX (w) register accessor: an alias for `Reg<TASKS_STARTRX_SPEC>`"]
 pub type TASKS_STARTRX = crate::Reg<tasks_startrx::TASKS_STARTRX_SPEC>;
@@ -158,3 +161,7 @@ pub mod txd;
 pub type ADDRESS = crate::Reg<address::ADDRESS_SPEC>;
 #[doc = "Address used in the TWI transfer"]
 pub mod address;
+#[doc = "PER_POWER (rw) register accessor: an alias for `Reg<PER_POWER_SPEC>`"]
+pub type PER_POWER = crate::Reg<per_power::PER_POWER_SPEC>;
+#[doc = "Peripheral power control register"]
+pub mod per_power;

--- a/pacs/nrf52832-pac/src/twim0/per_power.rs
+++ b/pacs/nrf52832-pac/src/twim0/per_power.rs
@@ -1,0 +1,64 @@
+#[doc = "Register `PER_POWER` reader"]
+pub struct R(crate::R<PER_POWER_SPEC>);
+impl core::ops::Deref for R {
+    type Target = crate::R<PER_POWER_SPEC>;
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+impl From<crate::R<PER_POWER_SPEC>> for R {
+    #[inline(always)]
+    fn from(reader: crate::R<PER_POWER_SPEC>) -> Self {
+        R(reader)
+    }
+}
+#[doc = "Register `PER_POWER` writer"]
+pub struct W(crate::W<PER_POWER_SPEC>);
+impl core::ops::Deref for W {
+    type Target = crate::W<PER_POWER_SPEC>;
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+impl core::ops::DerefMut for W {
+    #[inline(always)]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+impl From<crate::W<PER_POWER_SPEC>> for W {
+    #[inline(always)]
+    fn from(writer: crate::W<PER_POWER_SPEC>) -> Self {
+        W(writer)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.0.bits(bits);
+        self
+    }
+}
+#[doc = "Peripheral power control register\n\nThis register you can [`read`](crate::generic::Reg::read), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [per_power](index.html) module"]
+pub struct PER_POWER_SPEC;
+impl crate::RegisterSpec for PER_POWER_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [per_power::R](R) reader structure"]
+impl crate::Readable for PER_POWER_SPEC {
+    type Reader = R;
+}
+#[doc = "`write(|w| ..)` method takes [per_power::W](W) writer structure"]
+impl crate::Writable for PER_POWER_SPEC {
+    type Writer = W;
+}
+#[doc = "`reset()` method sets PER_POWER to value 0"]
+impl crate::Resettable for PER_POWER_SPEC {
+    #[inline(always)]
+    fn reset_value() -> Self::Ux {
+        0
+    }
+}

--- a/svds/nrf52832.svd
+++ b/svds/nrf52832.svd
@@ -11913,6 +11913,12 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\
             </field>
           </fields>
         </register>
+        <register>
+          <name>PER_POWER</name>
+          <description>Peripheral power control register</description>
+          <addressOffset>0xffc</addressOffset>
+          <access>read-write</access>
+        </register>
       </registers>
     </peripheral>
     <peripheral>


### PR DESCRIPTION
Due to Errata 89 from the [nrf52832 Erratas](https://infocenter.nordicsemi.com/topic/errata_nRF52832_Rev3/ERR/nRF52832/Rev3/latest/err_832.html) it may be necessary to alter some kind of hidden POWER register of the TWIM peripherals. This register is, according to the errata, found at address `0x4000_3FFC` for TWIM0.

Unfortunately that POWER register is not described anywhere except in the Errata, it is not in the Register List of the nRF52832 datasheet.

I did have some problems with power consumption using the TWIM and GPIOTE peripherals and writing to address space `0x4000_3FFC` as described in the errata fixes these power consumption issues, so that register **exists**, it is just not documented.

This PR adds said register to the SVD file.

![image](https://user-images.githubusercontent.com/9417983/218149274-ea4e7925-c92f-4e68-a5a9-2200b4f8bc90.png)
